### PR TITLE
Fix Zoom Video Conf Screen Share

### DIFF
--- a/config
+++ b/config
@@ -93,6 +93,7 @@ shadow-exclude = [
     "name = 'xfce4-notifyd'",
     "name *= 'VLC'",
     "name *= 'compton'",
+    "name *= 'cpt_frame_window'",
     "name *= 'Chromium'",
     "name *= 'Chrome'",
     "name *= 'wrapper-2.0'",


### PR DESCRIPTION
Fixes https://github.com/regolith-linux/regolith-compton-config/issues/2

Removes a dark overlay the obscures the screen when trying to share
my desktop when using the Zoom Video Conferencing software.