### PR TITLE
Added 'as_toolbar'

### DIFF
--- a/config
+++ b/config
@@ -95,6 +95,7 @@ shadow-exclude = [
     "name *= 'VLC'",
     "name *= 'compton'",
     "name *= 'cpt_frame_window'",
+    "name *= 'as_toolbar'",
     "name *= 'Chromium'",
     "name *= 'Chrome'",
     "name *= 'wrapper-2.0'",


### PR DESCRIPTION
Leo suggested adding 'as_toolbar' per the following URL

https://github.com/manveru/dotfiles/blob/master/kappa.nix#L67

This is an addition to this PR  https://github.com/regolith-linux/regolith-compton-config/pull/3